### PR TITLE
1-http-aware: Rename GET from /user to /users

### DIFF
--- a/JavaScript/1-http-aware/main.js
+++ b/JavaScript/1-http-aware/main.js
@@ -21,8 +21,8 @@ app.use(bodyParser.json());
 
 app.use(bodyParser.urlencoded({ extended: true }));
 
-app.get('/user', (req, res) => {
-  console.log(`${req.socket.remoteAddress} GET /user`);
+app.get('/users', (req, res) => {
+  console.log(`${req.socket.remoteAddress} GET /users`);
   pool.query('SELECT * FROM users', (err, data) => {
     if (err) throw err;
     res.status(200).json(data.rows);


### PR DESCRIPTION
We use SQL Query like: 
```sql
SELECT * FROM users 
```
It would be logical to rename from /user to /user**s**