### PR TITLE
FIx: pg driver's output goes beyond database layer

### DIFF
--- a/JavaScript/b-transport/db.js
+++ b/JavaScript/b-transport/db.js
@@ -11,8 +11,8 @@ const crud = (pool) => (table) => ({
   async read(id, fields = ['*']) {
     const names = fields.join(', ');
     const sql = `SELECT ${names} FROM ${table}`;
-    if (!id) return pool.query(sql);
-    return pool.query(`${sql} WHERE id = $1`, [id]);
+    if (!id) return this.query(sql);
+    return this.query(`${sql} WHERE id = $1`, [id]);
   },
 
   async create({ ...record }) {
@@ -27,7 +27,7 @@ const crud = (pool) => (table) => ({
     const fields = '"' + keys.join('", "') + '"';
     const params = nums.join(', ');
     const sql = `INSERT INTO "${table}" (${fields}) VALUES (${params})`;
-    return pool.query(sql, data);
+    return this.query(sql, data);
   },
 
   async update(id, { ...record }) {
@@ -42,12 +42,12 @@ const crud = (pool) => (table) => ({
     const delta = updates.join(', ');
     const sql = `UPDATE ${table} SET ${delta} WHERE id = $${++i}`;
     data.push(id);
-    return pool.query(sql, data);
+    return this.query(sql, data);
   },
 
   async delete(id) {
     const sql = 'DELETE FROM ${table} WHERE id = $1';
-    return pool.query(sql, [id]);
+    return this.query(sql, [id]);
   },
 });
 

--- a/JavaScript/b-transport/transport/http.js
+++ b/JavaScript/b-transport/transport/http.js
@@ -32,7 +32,7 @@ module.exports = (routing, port, console) => {
     if (!handler) return res.end('"Not found"');
     const { args } = await receiveArgs(req);
     console.log(`${socket.remoteAddress} ${method} ${url}`);
-    const result = await handler(args);
+    const result = await handler(...args);
     res.end(JSON.stringify(result));
   }).listen(port);
 

--- a/JavaScript/c-commonjs/db.js
+++ b/JavaScript/c-commonjs/db.js
@@ -17,8 +17,8 @@ const crud = (table) => ({
   async read(id, fields = ['*']) {
     const names = fields.join(', ');
     const sql = `SELECT ${names} FROM ${table}`;
-    if (!id) return pool.query(sql);
-    return pool.query(`${sql} WHERE id = $1`, [id]);
+    if (!id) return this.query(sql);
+    return this.query(`${sql} WHERE id = $1`, [id]);
   },
 
   async create({ ...record }) {
@@ -33,7 +33,7 @@ const crud = (table) => ({
     const fields = '"' + keys.join('", "') + '"';
     const params = nums.join(', ');
     const sql = `INSERT INTO "${table}" (${fields}) VALUES (${params})`;
-    return pool.query(sql, data);
+    return this.query(sql, data);
   },
 
   async update(id, { ...record }) {
@@ -48,12 +48,12 @@ const crud = (table) => ({
     const delta = updates.join(', ');
     const sql = `UPDATE ${table} SET ${delta} WHERE id = $${++i}`;
     data.push(id);
-    return pool.query(sql, data);
+    return this.query(sql, data);
   },
 
   async delete(id) {
     const sql = 'DELETE FROM ${table} WHERE id = $1';
-    return pool.query(sql, [id]);
+    return this.query(sql, [id]);
   },
 });
 

--- a/JavaScript/c-commonjs/transport/http.js
+++ b/JavaScript/c-commonjs/transport/http.js
@@ -32,7 +32,7 @@ module.exports = (routing, port, console) => {
     if (!handler) return res.end('"Not found"');
     const { args } = await receiveArgs(req);
     console.log(`${socket.remoteAddress} ${method} ${url}`);
-    const result = await handler(args);
+    const result = await handler(...args);
     res.end(JSON.stringify(result));
   }).listen(port);
 

--- a/JavaScript/d-messenger/lib/db.js
+++ b/JavaScript/d-messenger/lib/db.js
@@ -11,8 +11,8 @@ const crud = (pool) => (table) => ({
   async read(id, fields = ['*']) {
     const names = fields.join(', ');
     const sql = `SELECT ${names} FROM ${table}`;
-    if (!id) return pool.query(sql);
-    return pool.query(`${sql} WHERE id = $1`, [id]);
+    if (!id) return this.query(sql);
+    return this.query(`${sql} WHERE id = $1`, [id]);
   },
 
   async create({ ...record }) {
@@ -27,7 +27,7 @@ const crud = (pool) => (table) => ({
     const fields = '"' + keys.join('", "') + '"';
     const params = nums.join(', ');
     const sql = `INSERT INTO "${table}" (${fields}) VALUES (${params})`;
-    return pool.query(sql, data);
+    return this.query(sql, data);
   },
 
   async update(id, { ...record }) {
@@ -42,12 +42,12 @@ const crud = (pool) => (table) => ({
     const delta = updates.join(', ');
     const sql = `UPDATE ${table} SET ${delta} WHERE id = $${++i}`;
     data.push(id);
-    return pool.query(sql, data);
+    return this.query(sql, data);
   },
 
   async delete(id) {
     const sql = 'DELETE FROM ${table} WHERE id = $1';
-    return pool.query(sql, [id]);
+    return this.query(sql, [id]);
   },
 });
 


### PR DESCRIPTION
Signed-off-by: Vladyslav Karpenko <klarpen@gmail.com>

Начиная с примера `b-transport` оба варианта транспорта (`http & ws`) [возвращают результат выполнения API метода](https://github.com/HowProgrammingWorks/DDD/blob/f18dc3604ed51dee1416807d10e0f7e9f2a9b016/JavaScript/b-transport/transport/http.js#L35-L36) в исходном виде. Ранее именно на этом шаге выполнялась выборка только свойства `result.rows`, т.к. все API методы были завязаны на результат из БД.

Поскольку результат возвращаемый методами API сервисов [не изменился согласно правки транспорта](https://github.com/HowProgrammingWorks/DDD/blob/f18dc3604ed51dee1416807d10e0f7e9f2a9b016/JavaScript/b-transport/api/country.js#L6) — на клиента приходит оригинальный полный ответ от `pg` драйвера. 

<img width="924" alt="Знімок екрана 2023-01-15 о 11 08 16" src="https://user-images.githubusercontent.com/13551608/212536119-46feece2-fb51-4f61-a0ca-8f1d89666b5c.png">

Данная правка корректирует скрипт `db.js`, чтобы все методы возвращали масив результатов, а не полный объект ответа драйвера БД. В результате ответ API методов возвращается к состоянию согласно контракту предыдущих примеров.

<img width="428" alt="Знімок екрана 2023-01-15 о 12 22 00" src="https://user-images.githubusercontent.com/13551608/212536325-b702bbeb-4761-4260-8093-f5ec81d064bf.png">

Для испытания в файлы `static/client.js` добавлял сценарий
```js
await api.country.read(3);
await api.user.update(4, { login: 'iskandar', password: 'zulqarnayn' });
```
В исходниках там только запрос к `api.talks.say` который не проявляет ситуацию.

### Примечание

Решение предполагает, что ранее на мастер ветку уже был применён пул запрос #15 . В коде уже содержится соответствующая правка для `b-transport` и `c-commonjs`, но НЕ `d-message`. Поэтому логично применять #15 первым.