### PR TITLE
Fix client side API method arguments contract to become consistent with the server side

### DIFF
--- a/JavaScript/d-messenger/static/client.js
+++ b/JavaScript/d-messenger/static/client.js
@@ -67,6 +67,9 @@ const scaffold = (url) => {
       method: ['arg'],
     },
   });
-  const data = await api.auth.signin('marcus', 'marcus');
+  const data = await api.auth.signin({
+    login: 'marcus',
+    password: 'marcus',
+  });
   console.dir({ data });
 })();

--- a/JavaScript/d-messenger/transport/http.js
+++ b/JavaScript/d-messenger/transport/http.js
@@ -33,7 +33,7 @@ module.exports = (routing, port, console) => {
       if (!handler) return res.end('"Not found"');
       const { args } = await receiveArgs(req);
       console.log(`${socket.remoteAddress} ${method} ${url}`);
-      const result = await handler(args);
+      const result = await handler(...args);
       res.end(JSON.stringify(result));
     })
     .listen(port);


### PR DESCRIPTION
Исправление несовпадения контрактов методов API между клиентом и сервером в примере d-messenger, что было описано вопросом в дискуссии https://github.com/metatech-university/NodeJS-2022-2023/discussions/30 и обсуждено на созвоне Call #89 от 21.01.2023.

Применяет решение привести вызов API метода на клиенте в соответствие с контрактом на стороне сервера.

### Примечание

Решение предполагает, что ранее на мастер ветку уже был применён пул запрос #15 . В коде уже содержится соответствующая правка для `d-message`, но НЕ `b-transport` и `c-commonjs`. Поэтому логично применять #15 первым.